### PR TITLE
Adding ATOM_0_ENV so login scripts know that they're running under 0-env

### DIFF
--- a/lib/0-env.js
+++ b/lib/0-env.js
@@ -7,7 +7,7 @@ import {
 export default {
   activate: () => {
     execSync(
-        '$SHELL --login -i -c "env; exit"', {
+        'env ATOM_0_ENV=1 "$SHELL" --login -i -c "env -u ATOM_0_ENV env; exit"', {
           encoding: 'utf8'
         })
       .split('\n')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "0-env",
   "main": "./lib/0-env",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Populate Atom's env with user environment variables when loading from the launcher.",
   "keywords": [
     "environment",


### PR DESCRIPTION
Setting `ATOM_0_ENV=1` so that login scripts can tailor an environment specific to atom.